### PR TITLE
chore: añadir .kiro/ a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ replay_pid*
 .claude/
 GEMINI.md
 miMAPA.md
+.kiro/


### PR DESCRIPTION
Kiro CLI lee contexto vía .kiro/steering/context.md (symlink gestionado por myClaudeContext), igual que GEMINI.md. Se excluye del repo.